### PR TITLE
list only files, not directories, for use in get_random_image

### DIFF
--- a/src/dummy_thumbnails/base.py
+++ b/src/dummy_thumbnails/base.py
@@ -27,7 +27,6 @@ else:
 
 if not ABSOLUTE_IMAGES_PATH.endswith(os.path.sep):
     ABSOLUTE_IMAGES_PATH = os.path.join(ABSOLUTE_IMAGES_PATH, '')
-ABSOLUTE_IMAGES_PATH = os.path.join(ABSOLUTE_IMAGES_PATH, '*')
 
 OPTIONS = [filename for filename in os.listdir(ABSOLUTE_IMAGES_PATH)
            if os.path.isfile(os.path.join(ABSOLUTE_IMAGES_PATH, filename))]

--- a/src/dummy_thumbnails/base.py
+++ b/src/dummy_thumbnails/base.py
@@ -35,4 +35,4 @@ OPTIONS = [filename for filename in os.listdir(ABSOLUTE_IMAGES_PATH)
 def get_random_image():
     """Get random image."""
     random_image = random.randint(0, len(OPTIONS) - 1)
-    return OPTIONS[random_image]
+    return os.path.join(ABSOLUTE_IMAGES_PATH, OPTIONS[random_image])

--- a/src/dummy_thumbnails/base.py
+++ b/src/dummy_thumbnails/base.py
@@ -5,13 +5,9 @@ Base module.
 - OPTIONS: List of images to choose from.
 - get_random_image: Get a random image from the path given.
 """
-
-import glob
 import os
 import random
-
 from django.conf import settings
-
 from .settings import IMAGES_PATH
 
 __title__ = 'dummy_thumbnails.base'
@@ -24,7 +20,6 @@ __all__ = (
     'get_random_image',
 )
 
-
 if os.path.isabs(IMAGES_PATH):
     ABSOLUTE_IMAGES_PATH = IMAGES_PATH[:]
 else:
@@ -34,7 +29,8 @@ if not ABSOLUTE_IMAGES_PATH.endswith(os.path.sep):
     ABSOLUTE_IMAGES_PATH = os.path.join(ABSOLUTE_IMAGES_PATH, '')
 ABSOLUTE_IMAGES_PATH = os.path.join(ABSOLUTE_IMAGES_PATH, '*')
 
-OPTIONS = glob.glob(ABSOLUTE_IMAGES_PATH)
+OPTIONS = [filename for filename in os.listdir(ABSOLUTE_IMAGES_PATH)
+           if os.path.isfile(os.path.join(ABSOLUTE_IMAGES_PATH, filename))]
 
 
 def get_random_image():

--- a/src/dummy_thumbnails/contrib/thumbnailers/easy_thumbnails/source_generators.py
+++ b/src/dummy_thumbnails/contrib/thumbnailers/easy_thumbnails/source_generators.py
@@ -48,7 +48,7 @@ def dummy_thumbnail(source, exif_orientation=True, **options):
     # File objects.
     media_root = os.path.abspath(django_settings.MEDIA_ROOT)
 
-    if not (source and (os.path.exists(source.path)
+    if not (source and hasattr(source, 'path') and (os.path.exists(source.path)
                         or os.path.isfile(source.path))):
         random_image = get_random_image()
         random_file = open(random_image)

--- a/src/dummy_thumbnails/contrib/thumbnailers/easy_thumbnails/source_generators.py
+++ b/src/dummy_thumbnails/contrib/thumbnailers/easy_thumbnails/source_generators.py
@@ -13,6 +13,7 @@ import os
 from django.conf import settings as django_settings
 
 from easy_thumbnails.utils import exif_orientation as utils_exif_orientation
+from easy_thumbnails.files import ThumbnailFile
 
 from six import BytesIO
 
@@ -50,27 +51,33 @@ def dummy_thumbnail(source, exif_orientation=True, **options):
 
     if not (source and hasattr(source, 'path') and (os.path.exists(source.path)
                         or os.path.isfile(source.path))):
-        random_image = get_random_image()
-        random_file = open(random_image)
-        from easy_thumbnails.files import ThumbnailFile
-
-        source = ThumbnailFile(random_file.name, random_file)
-        # source._set_file(random_file)
-        source.name = source.file.name.replace(media_root, '')[1:]
+        source = load_random_file(media_root)
 
     buf = BytesIO(source.read())
 
-    image = Image.open(buf)
     # Fully load the image now to catch any problems with the image contents.
     try:
+        image = Image.open(buf)
         # An "Image file truncated" exception can occur for some images that
         # are still mostly valid -- we'll swallow the exception.
         image.load()
     except IOError:
-        pass
+        # Try again, loading another file
+        source = load_random_file(media_root)
+        buf = BytesIO(source.read())
+        image = Image.open(buf)
+
     # Try a second time to catch any other potential exceptions.
     image.load()
 
     if exif_orientation:
         image = utils_exif_orientation(image)
     return image
+
+
+def load_random_file(media_root):
+    random_image = get_random_image()
+    random_file = open(random_image)
+    source = ThumbnailFile(random_file.name, random_file)
+    source.name = source.file.name.replace(media_root, '')[1:]
+    return source


### PR DESCRIPTION
This is useful for preventing IO errors when linking to a (media) folder containing containing subdirectories.